### PR TITLE
added check for hidden file. doesn't compress hidden file

### DIFF
--- a/lib/minifier.ts
+++ b/lib/minifier.ts
@@ -28,6 +28,15 @@ export class Minifier {
     this.setPlatformPaths();
   }
   
+  /** Checks whether a path starts with or contains a hidden file or a folder.
+  * @param {string} source - The path of the file that needs to be validated.
+  * returns {boolean} - `true` if the source is blacklisted and otherwise `false`.
+  * Note: code is from http://stackoverflow.com/questions/8905680/nodejs-check-for-hidden-files/
+*/
+  private _isHiddenFile(file: string): boolean {
+      return (/(^|\/)\.[^\/\.]/g).test(file);
+  }
+  
   /**
    * Runs the compressor to minify files.
    */
@@ -76,7 +85,11 @@ export class Minifier {
             if (stat.isDirectory()){
               this.processFiles(file);  
             } else {
-              this.compress(file);
+              if(this._isHiddenFile(file)){
+                  console.log('Not processing hidden file: ' + file);
+              } else {
+                  this.compress(file);
+              }
             }
           });
         });


### PR DESCRIPTION
I was getting errors about trying to compress hidden files. 
In particular, there wasn't a file extension and so `toUpperCase()` was throwing an error that didn't make sense at the time. 

I'm not sure if all hidden files should be rejected, are there cases where hidden files should be? 
I should probably add a hook before minifying which removes hidden files because in my case they're not needed but maybe in some cases people have hidden files which they want bundled in their app but don't want them minified. 
